### PR TITLE
raise/test minimum protobuf version by trial-and-error, more imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/grpcio-health-c
 
 Summary: Standard Health Checking Service for gRPC
 
+Development: https://github.com/grpc/grpc/tree/master/src/python/grpcio_health_checking
+
 Current build status
 ====================
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Summary: Standard Health Checking Service for gRPC
 
 Development: https://github.com/grpc/grpc/tree/master/src/python/grpcio_health_checking
 
+Documentation: https://grpc.github.io/grpc/python/grpc_health_checking.html
+
 Current build status
 ====================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ about:
   license: Apache-2.0
   license_file: LICENSE
   dev_url: https://github.com/grpc/grpc/tree/master/src/python/grpcio_health_checking
+  doc_url: https://grpc.github.io/grpc/python/grpc_health_checking.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,9 @@
 {% set name = "grpcio-health-checking" %}
 {% set version = "1.33.2" %}
 
+# TODO: this upstream pin appears to not be updated w/r/t to code generation version
+{% set min_protobuf = "3.12.1" %}
+
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -10,7 +13,7 @@ source:
   sha256: 35f8bce59f5e3b16ac524f954597dc54195e3277b1d600c96f54fc64780ebdf6
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -20,7 +23,7 @@ requirements:
     - python >=3.5
   run:
     - grpcio >={{ version }}
-    - protobuf >=3.6.0
+    - protobuf >={{ min_protobuf }}
     - python >=3.5
 
 test:
@@ -28,17 +31,20 @@ test:
     - grpc_version.py
   imports:
     - grpc_health
-    - grpc_health.v1
+    - grpc_health.v1.health
   commands:
     - pip check
   requires:
     - pip
+    # do import tests with the minimum to assure it hasn't changed
+    - protobuf =={{ min_protobuf }}
 
 about:
   home: https://grpc.io
   summary: Standard Health Checking Service for gRPC
   license: Apache-2.0
   license_file: LICENSE
+  dev_url: https://github.com/grpc/grpc/tree/master/src/python/grpcio_health_checking
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,13 +9,17 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 35f8bce59f5e3b16ac524f954597dc54195e3277b1d600c96f54fc64780ebdf6
+  - folder: dist
+    url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 35f8bce59f5e3b16ac524f954597dc54195e3277b1d600c96f54fc64780ebdf6
+  - folder: src
+    url: https://github.com/grpc/grpc/archive/v{{ version }}.tar.gz
+    sha256: 2060769f2d4b0d3535ba594b2ab614d7f68a492f786ab94b4318788d45e3278a
 
 build:
   number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: cd dist && {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
@@ -28,14 +32,31 @@ requirements:
 
 test:
   source_files:
-    - grpc_version.py
+    # checked grpc version in run_test.py
+    - dist/grpc_version.py
+    # the actual tests to run under coverage
+    - src/src/python/grpcio_tests/tests/health_check/
+    # test imports
+    - src/src/python/grpcio_tests/tests/__init__.py
+    - src/src/python/grpcio_tests/tests/_loader.py
+    - src/src/python/grpcio_tests/tests/_result.py
+    - src/src/python/grpcio_tests/tests/_runner.py
+    - src/src/python/grpcio_tests/tests/unit/__init__.py
+    - src/src/python/grpcio_tests/tests/unit/framework/__init__.py
+    - src/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
+    - src/src/python/grpcio_tests/tests/unit/framework/common/test_constants.py
+    - src/src/python/grpcio_tests/tests/unit/test_common.py
+    - src/src/python/grpcio_tests/tests/unit/thread_pool.py
   imports:
     - grpc_health
     - grpc_health.v1.health
   commands:
     - pip check
+    - cd src/src/python/grpcio_tests
+    - pytest -vv -k health_check --cov grpc_health --cov-fail-under 77
   requires:
     - pip
+    - pytest-cov
     # do import tests with the minimum to assure it hasn't changed
     - protobuf =={{ min_protobuf }}
 
@@ -43,7 +64,7 @@ about:
   home: https://grpc.io
   summary: Standard Health Checking Service for gRPC
   license: Apache-2.0
-  license_file: LICENSE
+  license_file: dist/LICENSE
   dev_url: https://github.com/grpc/grpc/tree/master/src/python/grpcio_health_checking
   doc_url: https://grpc.github.io/grpc/python/grpc_health_checking.html
 

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -4,8 +4,9 @@
     Historically, the grpc_version.VERSION has always matched PKG_VERSION.
 """
 import os
-import grpc_version
 import sys
+sys.path.append("dist")
+import grpc_version
 
 PKG_VERSION = os.environ["PKG_VERSION"]
 GRPC_VERSION = grpc_version.VERSION


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- partially addresses #1
  - likely needs a https://github.com/conda-forge/admin-requests for `0`
- adds a more useful import (top-level was empty)
- bumps and tests against the minimum claimed version of `protobuf`
  - determined via trial-and-error
  - hopefully this approach will work in the future for determining the required version, as the `setup.py` data appears to be inaccurate (at least w/r/t the upstream tarball)
- adds some more URLs